### PR TITLE
Simplify Ruby's "do" block rule

### DIFF
--- a/autoload/lexima/endwise_rule.vim
+++ b/autoload/lexima/endwise_rule.vim
@@ -17,7 +17,7 @@ function! lexima#endwise_rule#make()
   " ruby
   call add(rules, s:make_rule('^\s*\%(module\|def\|class\|if\|unless\|for\|while\|until\|case\)\>\%(.*[^.:@$]\<end\>\)\@!.*\%#', 'end', 'ruby', []))
   call add(rules, s:make_rule('^\s*\%(begin\)\s*\%#', 'end', 'ruby', []))
-  call add(rules, s:make_rule('\%(^\s*#.*\)\@<!do\%(\s*|\k\+\%(\s*,\s*\k\+\)*|\)\?\s*\%#', 'end', 'ruby', []))
+  call add(rules, s:make_rule('\%(^\s*#.*\)\@<!do\%(\s*|.*|\)\?\s*\%#', 'end', 'ruby', []))
   call add(rules, s:make_rule('\<\%(if\|unless\)\>.*\%#', 'end', 'ruby', 'rubyConditionalExpression'))
 
   " sh

--- a/test/endwise_rules.vimspec
+++ b/test/endwise_rules.vimspec
@@ -36,7 +36,7 @@ Describe endwise rule
 
   Context in ruby
 
-    Before all
+    Before each
       new | setf ruby
     End
 
@@ -48,6 +48,14 @@ Describe endwise rule
       call Expect("a = if x\<CR>").to_change_input_as("a = if x\n\n    end")
     End
 
+    It should input end word for various do blocks
+      call Expect("hoge do\<CR>").to_change_input_as("hoge do\n\nend")
+      call Expect("hoge do |i, &block|\<CR>").to_change_input_as("hoge do |i, &block|\n\nend")
+      call Expect("hoge do |*args|\<CR>").to_change_input_as("hoge do |*args|\n\nend")
+      call Expect("hoge do |name: :default|\<CR>").to_change_input_as("hoge do |name: :default|\n\nend")
+      call Expect("hoge do |regex: /abc|def/| end\<CR>").to_change_input_as("hoge do |regex: /abc|def/| end\n")
+      call Expect("hoge do |i| end\<CR>").to_change_input_as("hoge do |i| end\n")
+    End
   End
 
 End


### PR DESCRIPTION
いつも便利にlexima.vimを使わせてもらっています。

Rubyの`do`ブロックについてなのですが、現状だとブロック受け取りや可変長引数で`&`や`*`を使うと`end`が補完されません。他にも、キーワード引数の存在を考えると結構色んなバリエーションがありえそうなので、`do`のルールはもう少しゆるめの正規表現でも良いのではないでしょうか?
