### PR TITLE
Correct 'disable lexima in clojure buffers' example

### DIFF
--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -202,8 +202,8 @@ b:lexima_disabled				*b:lexima_disabled*
 	If it is 1, all of lexima rules are disabled on the buffer.
 	(local to buffer)
 >
-	" Disable lexima.vim on clojure
-	autocmd FileType clojure let b:lexima_disabled = 0
+	" Disable lexima.vim in clojure buffers
+	autocmd FileType clojure let b:lexima_disabled = 1
 
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
The docs say you can disable lexima by setting `b:lexima_disabled` to `1`, but the example of disabling lexima for Clojure buffers has `b:lexima_disabled` set to `0`.