### PR TITLE
Implement lexima#add_rules()

### DIFF
--- a/autoload/lexima.vim
+++ b/autoload/lexima.vim
@@ -131,6 +131,17 @@ function! lexima#add_rule(rule)
   endif
 endfunction
 
+function! lexima#add_rules(rules, ...)
+  for rule in a:rules
+    let patchedrule = rule
+    if a:0 > 0
+      " Second argument is a filetype that should apply to each rule
+      let patchedrule = extend(copy(rule), {'filetype': a:1})
+    endif
+    call lexima#add_rule(patchedrule)
+  endfor
+endfunction
+
 function! lexima#expand(char, mode) abort
   if a:mode ==# 'i'
     return lexima#insmode#_expand(a:char)


### PR DESCRIPTION
This allows blocks of custom rules such as the following to be grouped
into the following more readable form:

    call lexima#add_rules([
            \ {'char': '<', 'at': '\w\%#', 'input_after': '>'},
            \ {'char': '>', 'at': '\%#>', 'leave': 1},
            \ {'char': '<BS>', 'at': '\w<\%#>', 'delete': 1},
    \ ], ['rust', 'cpp'])

Here, the three rules in the first argument are all passed separately to
lexima#add_rule.  In addition, each rule is only valid for the filetypes
'rust' and 'cpp'.