### PR TITLE
Fix endwise rules for filetype 'sh' and 'zsh'

### DIFF
--- a/autoload/lexima/endwise_rule.vim
+++ b/autoload/lexima/endwise_rule.vim
@@ -21,9 +21,9 @@ function! lexima#endwise_rule#make()
   call add(rules, s:make_rule('\<\%(if\|unless\)\>.*\%#', 'end', 'ruby', 'rubyConditionalExpression'))
 
   " sh
-  call add(rules, s:make_rule('^\s*if\>.*\%#', 'fi', ['sh', 'zsh'], ''))
-  call add(rules, s:make_rule('^\s*case\>.*\%#', 'esac', ['sh', 'zsh'], ''))
-  call add(rules, s:make_rule('\%(^\s*#.*\)\@<!do\>.*\%#', 'done', ['sh', 'zsh'], ''))
+  call add(rules, s:make_rule('^\s*if\>.*\%#', 'fi', ['sh', 'zsh'], []))
+  call add(rules, s:make_rule('^\s*case\>.*\%#', 'esac', ['sh', 'zsh'], []))
+  call add(rules, s:make_rule('\%(^\s*#.*\)\@<!do\>.*\%#', 'done', ['sh', 'zsh'], []))
 
   return rules
 endfunction

--- a/test/endwise_rules.vimspec
+++ b/test/endwise_rules.vimspec
@@ -58,4 +58,34 @@ Describe endwise rule
     End
   End
 
+  function! s:shared_examples_for_shells()
+      call Expect("if true\<CR>").to_change_input_as("if true\n\nfi")
+      call Expect("if true; then\<CR>").to_change_input_as("if true; then\n\nfi")
+      call Expect("case A in\<CR>").to_change_input_as("case A in\n\nesac")
+      call Expect("do\<CR>").to_change_input_as("do\n\ndone")
+      call Expect("for x in y; do\<CR>").to_change_input_as("for x in y; do\n\ndone")
+  endfunction
+
+  Context in sh
+
+    Before all
+      new | setf sh
+    End
+
+    It should input end word
+        call s:shared_examples_for_shells()
+    End
+  End
+
+  Context in zsh
+
+    Before all
+      new | setf zsh
+    End
+
+    It should input end word
+        call s:shared_examples_for_shells()
+    End
+  End
+
 End


### PR DESCRIPTION
`''` syntax is regularized to `['']` by `s:regularize(rule)` in lexiam.vim, so `s:find_rule(char)` in insmode.vim misses checking syntax.