### PR TITLE
Stop calling an autoload function from plugin/lexima.vim

### DIFF
--- a/plugin/lexima.vim
+++ b/plugin/lexima.vim
@@ -26,6 +26,11 @@ function! s:setup_insmode()
   endif
 endfun
 
+augroup lexima-init
+  autocmd!
+  autocmd InsertEnter * call lexima#init() | autocmd! lexima-init
+augroup END
+
 augroup lexima
   autocmd!
   autocmd InsertEnter * call lexima#insmode#clear_stack()

--- a/plugin/lexima.vim
+++ b/plugin/lexima.vim
@@ -29,6 +29,7 @@ endfun
 augroup lexima-init
   autocmd!
   autocmd InsertEnter * call lexima#init() | autocmd! lexima-init
+  autocmd InsertEnter * augroup! lexima-init
 augroup END
 
 augroup lexima

--- a/plugin/lexima.vim
+++ b/plugin/lexima.vim
@@ -6,8 +6,6 @@ if exists('g:loaded_lexima')
 endif
 let g:loaded_lexima = 1
 
-call lexima#init()
-
 
 if !exists('g:lexima_map_escape')
   let g:lexima_map_escape = '<Esc>'


### PR DESCRIPTION
Calling an autoload function from plugin/*.vim spoils the usage of
autoload functions.  Stop calling it.

(Some global variables or initialization code might be needed to move
from autoload/ to plugin/.)