### PR TITLE
Remove doc/tags from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 mysession.vim
 Gemfile.lock
 test/vendor/bundle
-doc/tags


### PR DESCRIPTION
I sent a pull request long ago adding it. Since then I became convinced that it should be added to a global gitignore, since not everyone generates it automatically (I thought they did)