### PR TITLE
Suppress W19

### DIFF
--- a/plugin/lexima.vim
+++ b/plugin/lexima.vim
@@ -29,7 +29,6 @@ endfun
 augroup lexima-init
   autocmd!
   autocmd InsertEnter * call lexima#init() | autocmd! lexima-init
-  autocmd InsertEnter * augroup! lexima-init
 augroup END
 
 augroup lexima


### PR DESCRIPTION
After 7.4.2117, warning W19 is shown.
Removing an augroup from inside of itself was bad idea.