### PR TITLE
Include option to disable nvim <cr> behavior

### DIFF
--- a/autoload/lexima.vim
+++ b/autoload/lexima.vim
@@ -12,6 +12,7 @@ let g:lexima_enable_basic_rules = get(g:, 'lexima_enable_basic_rules', 1)
 let g:lexima_enable_newline_rules = get(g:, 'lexima_enable_newline_rules', 1)
 let g:lexima_enable_space_rules = get(g:, 'lexima_enable_space_rules', 1)
 let g:lexima_enable_endwise_rules = get(g:, 'lexima_enable_endwise_rules', 1)
+let g:lexima_nvim_accept_pum_with_enter = get(g:, 'lexima_nvim_accept_pum_with_enter', 1)
 
 let s:lexima_vital = {
 \ 'L' : s:L,

--- a/autoload/lexima/insmode.vim
+++ b/autoload/lexima/insmode.vim
@@ -81,7 +81,7 @@ function! lexima#insmode#add_rules(rule) abort
   " Define imap in the last of the function in order to avoid invalid mapping
   " definition when an error occur.
   if newchar_flg
-    if has('nvim') && a:rule.char == '<CR>'
+    if has('nvim') && a:rule.char == '<CR>' && g:lexima_nvim_accept_pum_with_enter
       execute printf("inoremap <expr><silent> %s pumvisible() ? \"\\<C-y>\" : lexima#expand(%s, 'i')",
                     \ a:rule.char,
                     \ string(lexima#string#to_mappable(a:rule.char))

--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -199,6 +199,14 @@ g:lexima_enable_endwise_rules			*g:lexima_enable_endwise_rules*
 	If it is 1, |lexima-endwise-rules| are enabled by default.
 	default value: 1
 
+g:lexima_enable_nvim_accept_pum_with_enter	*g:lexima_nvim_accept_pum_with_enter*
+	If it is 1, enables <cr> to be used to accept completions when the
+	|popup-menu| is visible.
+	default value: 1
+>
+	" Always insert new line regardless if popup menu is visibel
+	let g:lexima_nvim_accept_pum_with_enter = 0
+
 b:lexima_disabled				*b:lexima_disabled*
 	If it is 1, all of lexima rules are disabled on the buffer.
 	(local to buffer)


### PR DESCRIPTION
I dislike the current behavior of having <cr> accept the current completion, so
I'm including an option to disable it.