### PR TITLE
Correctly specify <CR> mapping in lexima#expand example

### DIFF
--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -290,7 +290,7 @@ lexima#expand({char}, {mode})			*lexima#expand()*
 	You can customize the sequence by remapping this function.
 >
 	" Do nothing if some condition is fulfilled
-	inoremap <expr> <CR> someCondition() ? '' : lexima#expand('<CR>', 'i')
+	inoremap <expr> <CR> someCondition() ? '' : lexima#expand('<LT>CR>', 'i')
 <
 	If you remap keys, please add after |lexima#add_rule()|.
 


### PR DESCRIPTION
There was a typo preventing the given example from working as provided.
This would not occur in the plugin's source code, as it uses
`lexima#string#to_mappable('<cr>')` to transform strings to prevent this
issue. However, the example does not use this function, so it needs to
be updated.

I chose not to use to use `lexima#string#to_mappable` in the example in
case this API was not meant to be public.