### PR TITLE
Disable inoremap when b:lexima_disable is not 0

### DIFF
--- a/plugin/lexima.vim
+++ b/plugin/lexima.vim
@@ -19,6 +19,10 @@ if g:lexima_map_escape == '<Esc>' && !has('gui_running')
 endif
 
 function! s:setup_insmode()
+  if get(b:, 'lexima_disabled', 0)
+    return
+  endif
+
   if v:version > 703 || (v:version == 703 && has("patch1261"))
     exe 'inoremap <buffer> <silent> <nowait> '.g:lexima_map_escape.' <C-r>=lexima#insmode#escape()<CR><Esc>'
   else


### PR DESCRIPTION
Hi!

## What is the change
This PR suppresses lexime.vim creating mapping if `b:lexima_disable` is not 0.

## Why I need this PR
I would like to create buffer local `<ESC>` mapping of insert mode.

Here is a part of my `.vimrc` and `audocmd`s of my environment.
```vim
let b:lexima_disabled = 1
" It cannot work well because lexime.vim maps <ESC> when InsertEnter.
imap <silent><buffer><nowait> <ESC> <Plug>(denite_filter_quit)
nmap <silent><buffer><nowait> <ESC> <Plug>(denite_filter_quit)
```
https://github.com/mopp/dotfiles/blob/f0b69aaeca754127f3ffceb53a5407e8ceb8a511/.vimrc#L706-L712

So, lexime.vim overwrites my mapping for denite.nvim.