### PR TITLE
Fix variable name in doc

### DIFF
--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -239,7 +239,7 @@ g:lexima_enable_endwise_rules			*g:lexima_enable_endwise_rules*
 	If it is 1, |lexima-endwise-rules| are enabled by default.
 	default value: 1
 
-g:lexima_enable_nvim_accept_pum_with_enter	*g:lexima_nvim_accept_pum_with_enter*
+g:lexima_nvim_accept_pum_with_enter		*g:lexima_nvim_accept_pum_with_enter*
 	If it is 1, enables <cr> to be used to accept completions when the
 	|popup-menu| is visible.
 	default value: 1


### PR DESCRIPTION
Thanks to provided very useful plugin.

I fixed documentation.

Valid: `g:lexima_nvim_accept_pum_with_enter`.
Invalid: `g:lexima_enable_nvim_accept_pum_with_enter`.

(I think this option is very important.)