### PR TITLE
remove checking has('nvim')

### DIFF
--- a/autoload/lexima/insmode.vim
+++ b/autoload/lexima/insmode.vim
@@ -81,7 +81,7 @@ function! lexima#insmode#add_rules(rule) abort
   " Define imap in the last of the function in order to avoid invalid mapping
   " definition when an error occur.
   if newchar_flg
-    if has('nvim') && a:rule.char == '<CR>' && g:lexima_nvim_accept_pum_with_enter
+    if a:rule.char == '<CR>' && g:lexima_nvim_accept_pum_with_enter
       execute printf("inoremap <expr><silent> %s pumvisible() ? \"\\<C-y>\" : lexima#expand(%s, 'i')",
                     \ a:rule.char,
                     \ string(lexima#string#to_mappable(a:rule.char))


### PR DESCRIPTION
avoid \<cr\> conflict should be applied not only in nvim