### PR TITLE
Fix <Cr> not entering new line by default on Vim, and rename non-neovim-only var name not to scope to neovim

### DIFF
--- a/autoload/lexima.vim
+++ b/autoload/lexima.vim
@@ -18,7 +18,7 @@ if exists('g:lexima_nvim_accept_pum_with_enter')
   echohl None
   let g:lexima_accept_pum_with_enter = g:lexima_nvim_accept_pum_with_enter
 endif
-let g:lexima_accept_pum_with_enter = get(g:, 'lexima_accept_pum_with_enter', 0)
+let g:lexima_accept_pum_with_enter = get(g:, 'lexima_accept_pum_with_enter', has('nvim'))
 let g:lexima_ctrlh_as_backspace = get(g:, 'lexima_ctrlh_as_backspace', 0)
 
 let s:lexima_vital = {

--- a/autoload/lexima.vim
+++ b/autoload/lexima.vim
@@ -12,7 +12,13 @@ let g:lexima_enable_basic_rules = get(g:, 'lexima_enable_basic_rules', 1)
 let g:lexima_enable_newline_rules = get(g:, 'lexima_enable_newline_rules', 1)
 let g:lexima_enable_space_rules = get(g:, 'lexima_enable_space_rules', 1)
 let g:lexima_enable_endwise_rules = get(g:, 'lexima_enable_endwise_rules', 1)
-let g:lexima_nvim_accept_pum_with_enter = get(g:, 'lexima_nvim_accept_pum_with_enter', 1)
+if exists('g:lexima_nvim_accept_pum_with_enter')
+  echohl WarningMsg
+  echom 'lexima: g:lexima_nvim_accept_pum_with_enter is deprecated. Use g:lexima_accept_pum_with_enter instead.'
+  echohl None
+  let g:lexima_accept_pum_with_enter = g:lexima_nvim_accept_pum_with_enter
+endif
+let g:lexima_accept_pum_with_enter = get(g:, 'lexima_accept_pum_with_enter', 0)
 let g:lexima_ctrlh_as_backspace = get(g:, 'lexima_ctrlh_as_backspace', 0)
 
 let s:lexima_vital = {

--- a/autoload/lexima/insmode.vim
+++ b/autoload/lexima/insmode.vim
@@ -81,7 +81,7 @@ function! lexima#insmode#add_rules(rule) abort
   " Define imap in the last of the function in order to avoid invalid mapping
   " definition when an error occur.
   if newchar_flg
-    if a:rule.char == '<CR>' && g:lexima_nvim_accept_pum_with_enter
+    if a:rule.char == '<CR>' && g:lexima_accept_pum_with_enter
       execute printf("inoremap <expr><silent> %s pumvisible() ? \"\\<C-y>\" : lexima#expand(%s, 'i')",
                     \ a:rule.char,
                     \ string(lexima#string#to_mappable(a:rule.char))

--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -240,12 +240,20 @@ g:lexima_enable_endwise_rules			*g:lexima_enable_endwise_rules*
 	default value: 1
 
 g:lexima_nvim_accept_pum_with_enter		*g:lexima_nvim_accept_pum_with_enter*
+	Deprecated. Use g:lexima_accept_pum_with_enter instead.
+
+g:lexima_accept_pum_with_enter			*g:lexima_accept_pum_with_enter*
 	If it is 1, enables <cr> to be used to accept completions when the
 	|popup-menu| is visible.
-	default value: 1
+	default value: 0 in vim, and 1 in neovim
 >
+	" Don't insert new line if popup menu is visibel
+	let g:lexima_accept_pum_with_enter = 1
+
+	or
+
 	" Always insert new line regardless if popup menu is visibel
-	let g:lexima_nvim_accept_pum_with_enter = 0
+	let g:lexima_accept_pum_with_enter = 0
 
 g:lexima_ctrlh_as_backspace			*g:lexima_ctrlh_as_backspace*
 	If it is 1, <C-h> can be used in the same manner as <BS>.


### PR DESCRIPTION
This fixes https://github.com/cohama/lexima.vim/pull/99.

This changeset renames a global variable, but it doesn't destroy users' by providing implicit migration with deprecation warning, so it shouldn't hurt very much :)