### PR TITLE
Add rule key 'input_after_with' supporting backreferences

### DIFF
--- a/autoload/lexima/insmode.vim
+++ b/autoload/lexima/insmode.vim
@@ -176,6 +176,10 @@ function! s:map_impl(char)
       endif
       let input = input . rule.input
       let input_after = ''
+    elseif has_key(rule, 'input_after_with') && has_key(rule, 'at')
+      let line = getline(search(rule.at, 'bcWn', max([0, line('.') - 20])))
+      let input = rule.input
+      let input_after = substitute(line, substitute(rule.at, '\\%#', '', ''), rule.input_after_with, '')
     else
       let input = rule.input
       let input_after = rule.input_after

--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -344,6 +344,12 @@ input_after (String) (Optional)
 	Similar to "input" but this string is inserted after the cursor.
 	This is useful to input closing character such as ), }, ].
 
+input_after_with (Regex) (Optional)
+	Similar to "input_after" but can include backreferences which
+	reference capture groups in "at".
+	This is useful to input closing characters that include a substring
+	of the opening characters, such as "</div>".
+
 mode (String) (Optional)
 	Specify whether the rule is enabled on Insert mode and/or Command-line
 	mode.


### PR DESCRIPTION
This PR adds an additional rule key "input_after_with" which can use backreferences to capture groups in the key "at".

This allows creation of rules where the closing string requires a substring of the opening string, such as in HTML tags or LaTeX environments.

Example usage for LaTeX:
```vim
"" add endwise rule for LaTeX environments
call lexima#add_rule({
\ 'filetype': 'tex',
\ 'char': '<CR>',
\ 'input': '<CR>',
\ 'input_after_with': '<CR>\\end{\1}',
\ 'at': '^.*\\begin{\([^}]*\)}\(\[.*\]\)*\%#$'
\ })
```