### PR TITLE
Fix: ignore doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ mysession.vim
 /.plugintest.dein.cache/
 /.plugintest.vimrc
 /test/vim-themis
+/doc/tags
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ mysession.vim
 /.plugintest.vimrc
 /test/vim-themis
 /doc/tags
-


### PR DESCRIPTION
This prevents the `untracked content` error when adding lexima.vim as a submodule.
```cmd
> git submodule add -b master https://github.com/cohama/lexima.vim.git pack\plugins\start\lexima.vim
> git status
...

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
  (commit or discard the untracked or modified content in submodules)
        modified:   pack/plugins/start/lexima.vim (untracked content)
```
