### PR TITLE
Fix checking of backspace option

### DIFF
--- a/plugin/lexima.vim
+++ b/plugin/lexima.vim
@@ -23,7 +23,7 @@ function! s:setup_insmode()
     return
   endif
 
-  if !match(&backspace, 'start')
+  if -1 == match(&backspace, 'start')
     echohl WarningMsg
     echom "lexima: 'backspace' option does not contain 'start'. (Recommendation: set backspace=indent,eol,start)"
     echohl None


### PR DESCRIPTION
## problem

In my environment I get the following error even though the backspace option contains `start`.

#### error

```text
lexima: 'backspace' option does not contain 'start'. (Recommendation: set backspace=indent,eol,start)
```

#### my config

```vim
set backspace=start,eol,indent
```


## cause


The cause is the handling of the return value of `match()`.
Before the fix, it was checking if the return value was 0 or not.
If the backspace option has `start` at the beginning, an error will occur.

## solution

I have fixed it to check if the return value is -1 or not.
