### PR TITLE
feat: <CR> completions with pum.vim

### DIFF
--- a/autoload/lexima.vim
+++ b/autoload/lexima.vim
@@ -19,7 +19,7 @@ if exists('g:lexima_nvim_accept_pum_with_enter')
   let g:lexima_accept_pum_with_enter = g:lexima_nvim_accept_pum_with_enter
 endif
 let g:lexima_accept_pum_with_enter = get(g:, 'lexima_accept_pum_with_enter', has('nvim'))
-let g:lexima_accept_pum_with_enter = get(g:, 'lexima_accept_pumvim_with_enter', 0)
+let g:lexima_accept_pumvim_with_enter = get(g:, 'lexima_accept_pumvim_with_enter', 0)
 let g:lexima_ctrlh_as_backspace = get(g:, 'lexima_ctrlh_as_backspace', 0)
 let g:lexima_disable_on_nofile = get(g:, 'lexima_disable_on_nofile', 0)
 

--- a/autoload/lexima.vim
+++ b/autoload/lexima.vim
@@ -19,6 +19,7 @@ if exists('g:lexima_nvim_accept_pum_with_enter')
   let g:lexima_accept_pum_with_enter = g:lexima_nvim_accept_pum_with_enter
 endif
 let g:lexima_accept_pum_with_enter = get(g:, 'lexima_accept_pum_with_enter', has('nvim'))
+let g:lexima_accept_pum_with_enter = get(g:, 'lexima_accept_pumvim_with_enter', 0)
 let g:lexima_ctrlh_as_backspace = get(g:, 'lexima_ctrlh_as_backspace', 0)
 let g:lexima_disable_on_nofile = get(g:, 'lexima_disable_on_nofile', 0)
 

--- a/autoload/lexima/insmode.vim
+++ b/autoload/lexima/insmode.vim
@@ -82,11 +82,18 @@ function! lexima#insmode#add_rules(rule) abort
   " Define imap in the last of the function in order to avoid invalid mapping
   " definition when an error occur.
   if newchar_flg
-    if a:rule.char == '<CR>' && g:lexima_accept_pum_with_enter
-      execute printf("inoremap <expr><silent> %s pumvisible() ? \"\\<C-y>\" : lexima#expand(%s, 'i')",
-                    \ a:rule.char,
-                    \ string(lexima#string#to_mappable(a:rule.char))
-                    \ )
+    if a:rule.char == '<CR>'
+      if g:lexima_accept_pumvim_with_enter
+        execute printf("inoremap <expr><silent> %s pum#visible() ? '<Cmd>call pum#map#confirm()<CR>' : lexima#expand(%s, 'i')",
+                      \ a:rule.char,
+                      \ string(lexima#string#to_mappable(a:rule.char))
+                      \ )
+      elseif g:lexima_accept_pum_with_enter
+        execute printf("inoremap <expr><silent> %s pumvisible() ? \"\\<C-y>\" : lexima#expand(%s, 'i')",
+                      \ a:rule.char,
+                      \ string(lexima#string#to_mappable(a:rule.char))
+                      \ )
+      endif
     else
       execute printf("inoremap <expr><silent> %s lexima#expand(%s, 'i')",
                     \ a:rule.char,

--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -250,6 +250,11 @@ g:lexima_accept_pum_with_enter			*g:lexima_accept_pum_with_enter*
 	" Always insert new line regardless if popup menu is visible
 	let g:lexima_accept_pum_with_enter = 0
 
+g:lexima_accept_pumvim_with_enter		*g:lexima_accept_pumvim_with_enter*
+	If it is 1, enables <cr> to be used to accept completions when the
+	|pum.vim| (https://github.com/Shougo/pum.vim) is visible.
+	default value: 0
+
 g:lexima_ctrlh_as_backspace			*g:lexima_ctrlh_as_backspace*
 	If it is 1, <C-h> can be used in the same manner as <BS>.
 	default value: 0


### PR DESCRIPTION
I added `g:lexima_accept_pumvim_with_enter`.

This is like `g:lexima_accept_pum_with_enter`.  
When using [pum.vim](https://github.com/Shougo/pum.vim) as a popup completion menu, `g:lexima_accept_pum_with_enter` does not work.