### PR TITLE
Fixed: タグが被っていたので修正

### DIFF
--- a/doc/lexima.txt
+++ b/doc/lexima.txt
@@ -270,7 +270,7 @@ b:lexima_disabled				*b:lexima_disabled*
 	" Disable lexima.vim in clojure buffers
 	autocmd FileType clojure let b:lexima_disabled = 1
 
-b:lexima_disable_abbrev_trigger			*g:lexima_disable_abbrev_trigger*
+b:lexima_disable_abbrev_trigger			*b:lexima_disable_abbrev_trigger*
 	Same as |g:lexima_disable_abbrev_trigger| but only affects the
 	specified buffer.
 


### PR DESCRIPTION
追加された`b:lexima_disable_abbrev_trigger`のhelpタグが、
既存の`g:lexima_disable_abbrev_trigger`と被っていたので修正しました。