### PR TITLE
Suppress warning message at &backspace == 2

### DIFF
--- a/plugin/lexima.vim
+++ b/plugin/lexima.vim
@@ -17,7 +17,7 @@ function! s:setup_insmode()
     return
   endif
 
-  if -1 == match(&backspace, 'start')
+  if -1 == match(&backspace, 'start') && 2 != &backspace
     echohl WarningMsg
     echom "lexima: 'backspace' option does not contain 'start'. (Recommendation: set backspace=indent,eol,start)"
     echohl None


### PR DESCRIPTION
Suppress unnecessary warning message at `&backspace == 2`. because the help contains the following statement.

```
2	same as ":set backspace=indent,eol,start"
```