### PR TITLE
Fix duplicate augroup END on CR

### DIFF
--- a/autoload/lexima/endwise_rule.vim
+++ b/autoload/lexima/endwise_rule.vim
@@ -11,7 +11,7 @@ function! lexima#endwise_rule#make()
   endfor
   call add(rules, lexima#endwise_rule#make_rule('^\s*export def\>.*\%#$', 'enddef', 'vim', []))
   for at in ['aug', 'augroup']
-    call add(rules, lexima#endwise_rule#make_rule('^\s*' . at . '\s\+.\+\%#$', at . ' END', 'vim', []))
+    call add(rules, lexima#endwise_rule#make_rule('^\s*' . at . '\s\+\(END\)\@!.\+\%#$', at . ' END', 'vim', []))
   endfor
 
   " ruby

--- a/test/endwise_rules.vimspec
+++ b/test/endwise_rules.vimspec
@@ -36,6 +36,11 @@ Describe endwise rule
     It should input enddef after export def
       call Expect("export def\<CR>").to_change_input_as("export def\n\nenddef")
     End
+
+    It should not input duplicate augroup END
+      call Expect("augroup END\<CR>").to_change_input_as("augroup END\n")
+    End
+
   End
 
   Context in ruby


### PR DESCRIPTION
Hi @cohama,

When editing vimscript files if you enter `<CR>` after `augroup END` a duplicate `augroup END` is added.

I've updated the pattern to address this, by adding a negative lookahead to not match `augroup END`.

Hope this is useful :-) 