### PR TITLE
Update endwise rules - do not add end before catch, rescue, else etc.

### DIFF
--- a/autoload/lexima/endwise_rule.vim
+++ b/autoload/lexima/endwise_rule.vim
@@ -6,31 +6,37 @@ let s:cr_key = '<CR>'
 function! lexima#endwise_rule#make()
   let rules = []
   " vim
-  for at in ['fu', 'fun', 'func', 'funct', 'functi', 'functio', 'function', 'if', 'wh', 'whi', 'whil', 'while', 'for', 'try', 'def']
+  for at in ['fu', 'fun', 'func', 'funct', 'functi', 'functio', 'function', 'wh', 'whi', 'whil', 'while', 'for', 'def']
     call add(rules, lexima#endwise_rule#make_rule('^\s*' . at . '\>.*\%#$', 'end' . at, 'vim', []))
   endfor
   call add(rules, lexima#endwise_rule#make_rule('^\s*export def\>.*\%#$', 'enddef', 'vim', []))
+  call add(rules, lexima#endwise_rule#make_rule('^\s*try\>.*\%#$', 'endtry', 'vim', [], ['catch']))
+  call add(rules, lexima#endwise_rule#make_rule('^\s*if\>.*\%#$', 'endif', 'vim', [], ['else', 'elseif']))
   for at in ['aug', 'augroup']
     call add(rules, lexima#endwise_rule#make_rule('^\s*' . at . '\s\+.\+\%#$', at . ' END', 'vim', []))
   endfor
 
   " ruby
-  call add(rules, lexima#endwise_rule#make_rule('^\s*\%(module\|def\|class\|if\|unless\|for\|while\|until\|case\)\>\%(.*[^.:@$]\<end\>\)\@!.*\%#$', 'end', 'ruby', []))
-  call add(rules, lexima#endwise_rule#make_rule('^\s*\%(begin\)\s*\%#$', 'end', 'ruby', []))
+  call add(rules, lexima#endwise_rule#make_rule('^\s*\%(module\|class\|unless\|for\|while\|until\|case\)\>\%(.*[^.:@$]\<end\>\)\@!.*\%#$', 'end', 'ruby', []))
+  call add(rules, lexima#endwise_rule#make_rule('^\s*\%(if\)\>\%(.*[^.:@$]\<end\>\)\@!.*\%#$', 'end', 'ruby', [], ['else', 'elsif']))
+  call add(rules, lexima#endwise_rule#make_rule('^\s*\%(def\)\>\%(.*[^.:@$]\<end\>\)\@!.*\%#$', 'end', 'ruby', [], ['rescue']))
+  call add(rules, lexima#endwise_rule#make_rule('^\s*\%(begin\)\s*\%#$', 'end', 'ruby', [], ['rescue']))
   call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!do\%(\s*|.*|\)\?\s*\%#$', 'end', 'ruby', []))
   call add(rules, lexima#endwise_rule#make_rule('\<\%(if\|unless\)\>.*\%#$', 'end', 'ruby', 'rubyConditionalExpression'))
 
   " elixir
-  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!do\s*\%#$', 'end', 'elixir', []))
+  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!do\s*\%#$', 'end', 'elixir', [], ['rescue']))
 
   " sh
-  call add(rules, lexima#endwise_rule#make_rule('^\s*if\>.*\%#$', 'fi', ['sh', 'zsh'], []))
+  call add(rules, lexima#endwise_rule#make_rule('^\s*if\>.*\%#$', 'fi', ['sh', 'zsh'], [], ['else', 'elif']))
   call add(rules, lexima#endwise_rule#make_rule('^\s*case\>.*\%#$', 'esac', ['sh', 'zsh'], []))
   call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!do\>.*\%#$', 'done', ['sh', 'zsh'], []))
 
   " julia
-  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!\<\%(module\|struct\|function\|if\|for\|while\|do\|let\|macro\)\>\%(.*\<end\>\)\@!.*\%#$', 'end', 'julia', []))
-  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!\s*\<\%(begin\|try\|quote\)\s*\%#$', 'end', 'julia', []))
+  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!\<\%(module\|struct\|function\|for\|while\|do\|let\|macro\)\>\%(.*\<end\>\)\@!.*\%#$', 'end', 'julia', []))
+  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!\<\%(if\)\>\%(.*\<end\>\)\@!.*\%#$', 'end', 'julia', [], ['else', 'elseif']))
+  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!\s*\<\%(begin\|quote\)\s*\%#$', 'end', 'julia', []))
+  call add(rules, lexima#endwise_rule#make_rule('\%(^\s*#.*\)\@<!\s*\<try\s*\%#$', 'end', 'julia', [], ['catch']))
 
   " lua
   call add(rules, lexima#endwise_rule#make_rule('\%(^\s*--.*\)\@<!\<function\>\%(.*\<end\>\)\@!.*\%#$', 'end', 'lua', []))
@@ -40,13 +46,14 @@ function! lexima#endwise_rule#make()
   return rules
 endfunction
 
-function! lexima#endwise_rule#make_rule(at, end, filetype, syntax)
+function! lexima#endwise_rule#make_rule(at, end, filetype, syntax, ...)
+  let not_before = empty(a:000) ? [a:end] : [a:end] + a:1
   return {
   \ 'char': '<CR>',
   \ 'input': s:cr_key,
   \ 'input_after': '<CR>' . a:end,
   \ 'at': a:at,
-  \ 'except': '\C\v^(\s*)\S.*%#\n%(%(\s*|\1\s.+)\n)*\1' . a:end,
+  \ 'except': '\C\v^(\s*)\S.*%#\n%(%(\s*|\1\s.+)\n)*\1(' . not_before->join('|') . ')',
   \ 'filetype': a:filetype,
   \ 'syntax': a:syntax,
   \ }


### PR DESCRIPTION
Update endwise rules to avoid adding the end before certain keywords, e.g. no endtry before catch in vimscript or end before rescue in ruby.

Adds an optional argument to `lexima#endwise_rule#make_rule()` to specify an additional list of keywords before which the end is not added. Uses rest arguments to avoid breaking changes to the existing function signature.

I have not yet added any tests, primarily because I'm not sure how to test this using the existing test helpers.